### PR TITLE
Resource endpoint is authenticated

### DIFF
--- a/rst-api-spec.yaml.in
+++ b/rst-api-spec.yaml.in
@@ -530,8 +530,6 @@ paths:
       description: |
         This endpoint allows users to download [resources](https://icann.github.io/rst-test-specs/rst-test-specs.html#resources)
         which may be useful in preparing registry systems for testing.
-
-        There is no authentication on this endpoint.
       parameters:
         - name: file
           description: The name of the resource.


### PR DESCRIPTION
Despite the description, there is authentication on /v1/resource/ endpoint. Either there is an error in documentation or authentication is accidentally enabled.