### PR TITLE
closes #10

### DIFF
--- a/inc/test-request-base-properties.yaml
+++ b/inc/test-request-base-properties.yaml
@@ -10,8 +10,7 @@ rsp:
   description: |
     The RSP's unique ID.
 
-    In OT&E, this **MUST** contain the Fully-Qualified Domain Name where a TLSA
-    record that validates the client certificate is published.
+    In OT&E, this **MUST** be omitted when creating a new test request.
   type: string
   example: RSPI2404-M51
 


### PR DESCRIPTION
Update spec to match implementation: `rsp` property **MUST** be omitted when creating a new test in OT&E.